### PR TITLE
New link for installing miniconda

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -101,6 +101,8 @@ Conda is a package and environment manager that we will be using throughout this
 
 ### Download and install miniconda [here](https://www.anaconda.com/docs/getting-started/miniconda/main)
 
+### Download and install miniconda [here](https://www.anaconda.com/docs/getting-started/miniconda/install#quickstart-install-instructions)
+
 > Windows WSL users, please follow instructions for Linux/Unix
 
 ## DBeaver


### PR DESCRIPTION
Added a new link for installing miniconda. This link brings the user directly to the installation page, whereas the old link brings the user to the miniconda main page. See if this is preferred.